### PR TITLE
ドキュメントのタイトルの表記揺れを修正

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -3,7 +3,7 @@ authors = ["Seasawher"]
 language = "ja"
 multilingual = false
 src = "src"
-title = "Mathematics in type theory 日本語版"
+title = "Mathematics in type theory 日本語訳"
 
 [output.html]
 git-repository-url = "https://github.com/lean-ja/math-in-type-theory-ja"


### PR DESCRIPTION
`book.toml`内のドキュメントタイトルの表記揺れ(日本語版)を、
`src/README.md`、`src/SUMMARY.md`内のドキュメントタイトルの表記(日本語訳)に修正しました。